### PR TITLE
Use relative header path in modulemap

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -1,5 +1,5 @@
 module CSQLite [system] {
-    header "/usr/include/sqlite3.h"
+    header "sqlite3.h"
     link "sqlite3"
     export *
 }


### PR DESCRIPTION
Using a relative path makes it much easier to e.g. use SQLite headers from a custom sysroot when cross-compiling.